### PR TITLE
Organize GPU benchmarks into modules

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "common.h"
+#include "memory_bandwidth.h"
+#include "compute_perf.h"
+#include "parallelism.h"
+#include "texture_perf.h"
+#include "stress_test.h"
+

--- a/include/benchmark/common.h
+++ b/include/benchmark/common.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <stdio.h>
+#include <stdlib.h>
+#include <cuda_runtime.h>
+#include <sys/time.h>
+
+#define GPU_CHECK(call) \
+    do { \
+        cudaError_t err = call; \
+        if (err != cudaSuccess) { \
+            fprintf(stderr, "CUDA error at %s:%d - %s\n", __FILE__, __LINE__, cudaGetErrorString(err)); \
+            exit(EXIT_FAILURE); \
+        } \
+    } while (0)
+
+namespace gpu_benchmark {
+inline double get_time_ms() {
+    struct timeval tv;
+    gettimeofday(&tv, nullptr);
+    return (double)tv.tv_sec * 1000.0 + (double)tv.tv_usec / 1000.0;
+}
+}

--- a/include/benchmark/compute_perf.h
+++ b/include/benchmark/compute_perf.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace gpu_benchmark {
+float testComputePerformance(int numElements, int computeIterations);
+}

--- a/include/benchmark/memory_bandwidth.h
+++ b/include/benchmark/memory_bandwidth.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace gpu_benchmark {
+float testMemoryBandwidth(int size);
+}

--- a/include/benchmark/parallelism.h
+++ b/include/benchmark/parallelism.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace gpu_benchmark {
+float testParallelism(int numThreads);
+}

--- a/include/benchmark/stress_test.h
+++ b/include/benchmark/stress_test.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace gpu_benchmark {
+float stressTest(int durationSec);
+}

--- a/include/benchmark/texture_perf.h
+++ b/include/benchmark/texture_perf.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace gpu_benchmark {
+float testTexturePerformance(int width, int height);
+}

--- a/src/compute_perf.cu
+++ b/src/compute_perf.cu
@@ -1,0 +1,58 @@
+#include "benchmark/compute_perf.h"
+#include "benchmark/common.h"
+#include <math.h>
+
+namespace gpu_benchmark {
+
+__global__ void computeIntensiveKernel(float* input, float* output, int n, int iterations) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n) {
+        float val = input[idx];
+        for (int i = 0; i < iterations; ++i) {
+            val = sinf(val) * cosf(val) + sqrtf(fabsf(val)) + expf(val * 0.01f);
+        }
+        output[idx] = val;
+    }
+}
+
+float testComputePerformance(int numElements, int computeIterations) {
+    size_t bytes = numElements * sizeof(float);
+
+    printf("\n==== Compute Performance Test ====\n");
+    printf("Elements: %d, Iterations: %d\n", numElements, computeIterations);
+
+    float* h_input = (float*)malloc(bytes);
+    float* h_output = (float*)malloc(bytes);
+    for (int i = 0; i < numElements; ++i) {
+        h_input[i] = rand() / (float)RAND_MAX;
+    }
+
+    float *d_input, *d_output;
+    GPU_CHECK(cudaMalloc((void**)&d_input, bytes));
+    GPU_CHECK(cudaMalloc((void**)&d_output, bytes));
+    GPU_CHECK(cudaMemcpy(d_input, h_input, bytes, cudaMemcpyHostToDevice));
+
+    int threadsPerBlock = 256;
+    int blocksPerGrid = (numElements + threadsPerBlock - 1) / threadsPerBlock;
+
+    computeIntensiveKernel<<<blocksPerGrid, threadsPerBlock>>>(d_input, d_output, numElements, 1);
+    GPU_CHECK(cudaDeviceSynchronize());
+
+    double start = get_time_ms();
+    computeIntensiveKernel<<<blocksPerGrid, threadsPerBlock>>>(d_input, d_output, numElements, computeIterations);
+    GPU_CHECK(cudaDeviceSynchronize());
+    double end = get_time_ms();
+
+    double elapsed = (end - start) / 1000.0;
+    double gflops = (numElements * computeIterations * 5.0) / (elapsed * 1.0e9);
+    printf("Performance: %.2f GFLOPS\n", gflops);
+
+    GPU_CHECK(cudaFree(d_input));
+    GPU_CHECK(cudaFree(d_output));
+    free(h_input);
+    free(h_output);
+
+    return gflops;
+}
+
+} // namespace gpu_benchmark

--- a/src/main.cu
+++ b/src/main.cu
@@ -1,0 +1,63 @@
+#include "benchmark/benchmark.h"
+#include <stdio.h>
+
+namespace gpu_benchmark {
+
+static void showGPUInfo(int* computeCapability, int* coreCount, float* memoryGB) {
+    cudaDeviceProp prop;
+    int device;
+    GPU_CHECK(cudaGetDevice(&device));
+    GPU_CHECK(cudaGetDeviceProperties(&prop, device));
+
+    *computeCapability = prop.major * 10 + prop.minor;
+    *coreCount = prop.multiProcessorCount;
+    *memoryGB = prop.totalGlobalMem / (1024.0f * 1024.0f * 1024.0f);
+
+    printf("\n==== GPU Info ====\n");
+    printf("Name: %s\n", prop.name);
+    printf("Compute Capability: %d.%d\n", prop.major, prop.minor);
+    printf("Multiprocessors: %d\n", prop.multiProcessorCount);
+    printf("Memory: %.2f GB\n", *memoryGB);
+}
+
+static void calculateGPUScore(float memBandwidth, float computePerf, float parallelPerf, float texturePerf, float stressPerf,
+                              int computeCapability, int coreCount, float memoryGB) {
+    float baseScore = 100.0f;
+    float score = baseScore * (
+        0.2f * (memBandwidth / 300.0f) +
+        0.25f * (computePerf / 10000.0f) +
+        0.2f * (parallelPerf / 5.0f) +
+        0.15f * (texturePerf / 1000.0f) +
+        0.2f * (stressPerf / 5.0f));
+
+    float bonus = 1.0f;
+    if (computeCapability >= 70) bonus += 0.1f;
+    if (coreCount > 30) bonus += 0.1f;
+    if (memoryGB > 8.0f) bonus += 0.1f;
+
+    score *= bonus;
+
+    printf("\nTotal Score: %.1f\n", score);
+}
+
+} // namespace gpu_benchmark
+
+int main() {
+    using namespace gpu_benchmark;
+    int computeCapability = 0;
+    int coreCount = 0;
+    float memoryGB = 0.0f;
+
+    showGPUInfo(&computeCapability, &coreCount, &memoryGB);
+
+    float memBandwidth = testMemoryBandwidth(512 * 1024 * 1024);
+    float computePerf = testComputePerformance(5000000, 1000);
+    float parallelPerf = testParallelism(10000000);
+    float texturePerf = testTexturePerformance(1024, 1024);
+    float stressPerf = stressTest(10);
+
+    calculateGPUScore(memBandwidth, computePerf, parallelPerf, texturePerf, stressPerf,
+                      computeCapability, coreCount, memoryGB);
+
+    return 0;
+}

--- a/src/memory_bandwidth.cu
+++ b/src/memory_bandwidth.cu
@@ -1,0 +1,58 @@
+#include "benchmark/memory_bandwidth.h"
+#include "benchmark/common.h"
+#include <math.h>
+
+namespace gpu_benchmark {
+
+__global__ void memoryBandwidthKernel(float* input, float* output, int n) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n) {
+        output[idx] = input[idx];
+    }
+}
+
+float testMemoryBandwidth(int size) {
+    int numElements = size / sizeof(float);
+    size_t bytes = numElements * sizeof(float);
+
+    printf("==== Memory Bandwidth Test ====\n");
+    printf("Data Size: %.2f MB\n", bytes / (1024.0 * 1024.0));
+
+    float* h_input = (float*)malloc(bytes);
+    float* h_output = (float*)malloc(bytes);
+    for (int i = 0; i < numElements; ++i) {
+        h_input[i] = rand() / (float)RAND_MAX;
+    }
+
+    float *d_input, *d_output;
+    GPU_CHECK(cudaMalloc((void**)&d_input, bytes));
+    GPU_CHECK(cudaMalloc((void**)&d_output, bytes));
+    GPU_CHECK(cudaMemcpy(d_input, h_input, bytes, cudaMemcpyHostToDevice));
+
+    int threadsPerBlock = 256;
+    int blocksPerGrid = (numElements + threadsPerBlock - 1) / threadsPerBlock;
+
+    memoryBandwidthKernel<<<blocksPerGrid, threadsPerBlock>>>(d_input, d_output, numElements);
+    GPU_CHECK(cudaDeviceSynchronize());
+
+    int iterations = 20;
+    double start = get_time_ms();
+    for (int i = 0; i < iterations; ++i) {
+        memoryBandwidthKernel<<<blocksPerGrid, threadsPerBlock>>>(d_input, d_output, numElements);
+    }
+    GPU_CHECK(cudaDeviceSynchronize());
+    double end = get_time_ms();
+
+    double elapsed = (end - start) / 1000.0;
+    double bandwidth = (2.0 * bytes * iterations) / (elapsed * 1.0e9);
+    printf("Bandwidth: %.2f GB/s\n", bandwidth);
+
+    GPU_CHECK(cudaFree(d_input));
+    GPU_CHECK(cudaFree(d_output));
+    free(h_input);
+    free(h_output);
+
+    return bandwidth;
+}
+
+} // namespace gpu_benchmark

--- a/src/parallelism.cu
+++ b/src/parallelism.cu
@@ -1,0 +1,47 @@
+#include "benchmark/parallelism.h"
+#include "benchmark/common.h"
+
+namespace gpu_benchmark {
+
+__global__ void parallelismKernel(float* data, int n) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n) {
+        float val = data[idx];
+        atomicAdd(&data[0], val * 0.000001f);
+    }
+}
+
+float testParallelism(int numThreads) {
+    printf("\n==== Parallelism Test ====\n");
+    printf("Threads: %d\n", numThreads);
+
+    size_t bytes = numThreads * sizeof(float);
+    float* h_data = (float*)malloc(bytes);
+    for (int i = 0; i < numThreads; ++i) h_data[i] = 1.0f;
+
+    float* d_data;
+    GPU_CHECK(cudaMalloc((void**)&d_data, bytes));
+    GPU_CHECK(cudaMemcpy(d_data, h_data, bytes, cudaMemcpyHostToDevice));
+
+    int threadsPerBlock = 256;
+    int blocksPerGrid = (numThreads + threadsPerBlock - 1) / threadsPerBlock;
+
+    parallelismKernel<<<blocksPerGrid, threadsPerBlock>>>(d_data, numThreads);
+    GPU_CHECK(cudaDeviceSynchronize());
+
+    double start = get_time_ms();
+    parallelismKernel<<<blocksPerGrid, threadsPerBlock>>>(d_data, numThreads);
+    GPU_CHECK(cudaDeviceSynchronize());
+    double end = get_time_ms();
+
+    double elapsed = (end - start) / 1000.0;
+    double threadsPerSec = numThreads / (elapsed * 1.0e6);
+    printf("Threads per second: %.2f million\n", threadsPerSec);
+
+    GPU_CHECK(cudaFree(d_data));
+    free(h_data);
+
+    return threadsPerSec;
+}
+
+} // namespace gpu_benchmark

--- a/src/stress_test.cu
+++ b/src/stress_test.cu
@@ -1,0 +1,60 @@
+#include "benchmark/stress_test.h"
+#include "benchmark/common.h"
+#include <math.h>
+
+namespace gpu_benchmark {
+
+__global__ void stressKernel(float* input, float* output, int n, int iterations) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n) {
+        float val = input[idx];
+        for (int i = 0; i < iterations; ++i) {
+            val = sinf(val) * cosf(val) + sqrtf(fabsf(val)) + expf(val * 0.01f);
+        }
+        output[idx] = val;
+    }
+}
+
+float stressTest(int durationSec) {
+    printf("\n==== Stress Test (%d sec) ====\n", durationSec);
+
+    int numElements = 10000000;
+    size_t bytes = numElements * sizeof(float);
+
+    float *d_input, *d_output;
+    GPU_CHECK(cudaMalloc((void**)&d_input, bytes));
+    GPU_CHECK(cudaMalloc((void**)&d_output, bytes));
+
+    float* h_input = (float*)malloc(bytes);
+    for (int i = 0; i < numElements; ++i) h_input[i] = rand() / (float)RAND_MAX;
+    GPU_CHECK(cudaMemcpy(d_input, h_input, bytes, cudaMemcpyHostToDevice));
+
+    int threadsPerBlock = 256;
+    int blocksPerGrid = (numElements + threadsPerBlock - 1) / threadsPerBlock;
+
+    printf("Starting stress test...\n");
+    double start = get_time_ms();
+    double current = start;
+    int iterations = 0;
+    while ((current - start) < durationSec * 1000.0) {
+        stressKernel<<<blocksPerGrid, threadsPerBlock>>>(d_input, d_output, numElements, 100);
+        GPU_CHECK(cudaDeviceSynchronize());
+        float* tmp = d_input; d_input = d_output; d_output = tmp;
+        iterations++;
+        current = get_time_ms();
+    }
+
+    double elapsed = (current - start) / 1000.0;
+    double iterPerSec = iterations / elapsed;
+
+    printf("Iterations: %d\n", iterations);
+    printf("Average iterations/sec: %.2f\n", iterPerSec);
+
+    GPU_CHECK(cudaFree(d_input));
+    GPU_CHECK(cudaFree(d_output));
+    free(h_input);
+
+    return iterPerSec;
+}
+
+} // namespace gpu_benchmark

--- a/src/texture_perf.cu
+++ b/src/texture_perf.cu
@@ -1,0 +1,90 @@
+#include "benchmark/texture_perf.h"
+#include "benchmark/common.h"
+#include <string.h>
+
+namespace gpu_benchmark {
+
+__global__ void textureAccessKernel(float* output, cudaTextureObject_t texObj, int width, int height) {
+    int x = blockIdx.x * blockDim.x + threadIdx.x;
+    int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x < width && y < height) {
+        float u = x / (float)width;
+        float v = y / (float)height;
+        float4 texValue = tex2D<float4>(texObj, u, v);
+        int idx = y * width + x;
+        output[idx] = texValue.x + texValue.y + texValue.z + texValue.w;
+    }
+}
+
+float testTexturePerformance(int width, int height) {
+    printf("\n==== Texture Test ====\n");
+    printf("Texture size: %d x %d\n", width, height);
+
+    size_t texelSize = 4 * sizeof(float);
+    size_t texSize = width * height * texelSize;
+
+    float4* h_texData = (float4*)malloc(texSize);
+    for (int i = 0; i < width * height; ++i) {
+        h_texData[i] = make_float4(
+            rand() / (float)RAND_MAX,
+            rand() / (float)RAND_MAX,
+            rand() / (float)RAND_MAX,
+            rand() / (float)RAND_MAX);
+    }
+
+    float4* d_texData;
+    GPU_CHECK(cudaMalloc((void**)&d_texData, texSize));
+    GPU_CHECK(cudaMemcpy(d_texData, h_texData, texSize, cudaMemcpyHostToDevice));
+
+    cudaChannelFormatDesc channelDesc = cudaCreateChannelDesc<float4>();
+    cudaArray_t cuArray;
+    GPU_CHECK(cudaMallocArray(&cuArray, &channelDesc, width, height));
+    cudaMemcpy2DToArray(cuArray, 0, 0, h_texData, width * texelSize,
+                         width * texelSize, height, cudaMemcpyHostToDevice);
+
+    cudaResourceDesc resDesc;
+    memset(&resDesc, 0, sizeof(resDesc));
+    resDesc.resType = cudaResourceTypeArray;
+    resDesc.res.array.array = cuArray;
+
+    cudaTextureDesc texDesc;
+    memset(&texDesc, 0, sizeof(texDesc));
+    texDesc.addressMode[0] = cudaAddressModeWrap;
+    texDesc.addressMode[1] = cudaAddressModeWrap;
+    texDesc.filterMode = cudaFilterModeLinear;
+    texDesc.normalizedCoords = 1;
+
+    cudaTextureObject_t texObj = 0;
+    GPU_CHECK(cudaCreateTextureObject(&texObj, &resDesc, &texDesc, NULL));
+
+    float* d_output;
+    GPU_CHECK(cudaMalloc((void**)&d_output, width * height * sizeof(float)));
+
+    dim3 block(16,16);
+    dim3 grid((width + block.x - 1) / block.x, (height + block.y - 1) / block.y);
+
+    textureAccessKernel<<<grid, block>>>(d_output, texObj, width, height);
+    GPU_CHECK(cudaDeviceSynchronize());
+
+    int iterations = 100;
+    double start = get_time_ms();
+    for (int i = 0; i < iterations; ++i) {
+        textureAccessKernel<<<grid, block>>>(d_output, texObj, width, height);
+    }
+    GPU_CHECK(cudaDeviceSynchronize());
+    double end = get_time_ms();
+
+    double elapsed = (end - start) / 1000.0;
+    double texelRate = (width * height * iterations) / (elapsed * 1.0e6);
+    printf("Texture access rate: %.2f M/s\n", texelRate);
+
+    GPU_CHECK(cudaDestroyTextureObject(texObj));
+    GPU_CHECK(cudaFreeArray(cuArray));
+    GPU_CHECK(cudaFree(d_output));
+    GPU_CHECK(cudaFree(d_texData));
+    free(h_texData);
+
+    return texelRate;
+}
+
+} // namespace gpu_benchmark


### PR DESCRIPTION
## Summary
- add a modular `include/` API for GPU benchmarks
- implement each test in `src/`
- create a main program that runs all tests

## Testing
- `nvcc -o gpu_benchmark src/main.cu src/memory_bandwidth.cu src/compute_perf.cu src/parallelism.cu src/texture_perf.cu src/stress_test.cu -Iinclude -rdc=true -lm` *(fails: `nvcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847d16f3ad4832c92011c6a070f8b95